### PR TITLE
Fix README links

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -26,13 +26,13 @@ workflows:
           requires:
             - sym/request
           filters: *filters
-        - sym/deescalate:
+      - sym/deescalate:
           request_slug: "request-test"
           sym_api_url: "https://api.staging.symops.com/api/v1"
           requires:
             - wait_for_auto_approve
           filters: *filters
-        - orb-tools/pack:
+      - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
           orb-name: sym/sym

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -25,12 +25,14 @@ workflows:
           type: approval
           requires:
             - sym/request
-      - sym/deescalate:
+          filters: *filters
+        - sym/deescalate:
           request_slug: "request-test"
           sym_api_url: "https://api.staging.symops.com/api/v1"
           requires:
             - wait_for_auto_approve
-      - orb-tools/pack:
+          filters: *filters
+        - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
           orb-name: sym/sym

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sym API Orb 
 
 
-[![CircleCI Build Status](https://circleci.com/gh/symopsio/sym-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/symopsio/sym-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/sym/sym-orb.svg)](https://circleci.com/orbs/registry/orb/sym/sym-orb) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/symopsio/sym-orb/main/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
+[![CircleCI Build Status](https://circleci.com/gh/symopsio/sym-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/symopsio/sym-orb) [![CircleCI Orb Version](https://badges.circleci.com/orbs/sym/sym.svg)](https://circleci.com/orbs/registry/orb/sym/sym) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/symopsio/sym-orb/main/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
 Send Sym API requests from your CircleCI pipelines.
 
@@ -22,7 +22,7 @@ For more detailed documentation about Sym Bots and Tokens, visit the Sym Docs: [
 ---
 
 ## Resources
-- [CircleCI Orb Registry Page](https://circleci.com/orbs/registry/orb/sym/sym-orb) - The official registry page of this orb for all versions, executors, commands, and jobs described.
+- [CircleCI Orb Registry Page](https://circleci.com/orbs/registry/orb/sym/sym) - The official registry page of this orb for all versions, executors, commands, and jobs described.
 - [Sym Documentation](https://docs.symops.com/docs) - The official docs page for Sym
 
 ### How to Contribute


### PR DESCRIPTION
# Summary
- Fixes Orb registry links in README.md
- Also ensures that the de-escalate job is also tested when cutting a new release