### PR TITLE
Add alternate context collection options (stacked)

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -26,11 +26,17 @@ workflows:
           requires:
             - sym/request
           filters: *filters
-      - sym/deescalate:
+      - sym/validate:
           request_slug: "request-test"
           sym_api_url: "https://api.staging.symops.com/api/v1"
           requires:
             - wait_for_auto_approve
+          filters: *filters
+      - sym/deescalate:
+          request_slug: "request-test"
+          sym_api_url: "https://api.staging.symops.com/api/v1"
+          requires:
+            - sym/validate
           filters: *filters
       - orb-tools/pack:
           filters: *filters

--- a/src/commands/request.yml
+++ b/src/commands/request.yml
@@ -34,6 +34,7 @@ steps:
   - run:
       name: Collect context
       command: <<include(scripts/collect_context.sh)>>
+      working_directory: /tmp/workspace
   - run:
       environment:
         FLOW_SRN: <<parameters.flow_srn>>

--- a/src/commands/request.yml
+++ b/src/commands/request.yml
@@ -33,7 +33,7 @@ parameters:
 steps:
   - run:
       name: Collect context
-      command: <<include(scripts/collect_context.py)>>
+      command: <<include(scripts/collect_context.sh)>>
   - run:
       environment:
         FLOW_SRN: <<parameters.flow_srn>>

--- a/src/commands/request.yml
+++ b/src/commands/request.yml
@@ -19,6 +19,8 @@ parameters:
 
       The context can also be supplied by providing data in the workspace, either as
       sym/context.json or as a collection of files in the sym/context folder.
+
+      Binary files in the sym/context folder are not supported. JSON files will be encoded as strings.
     default: "{}"
   request_slug:
     type: string

--- a/src/commands/request.yml
+++ b/src/commands/request.yml
@@ -15,7 +15,10 @@ parameters:
     type: string
     description: |
       A valid JSON string containing the object to include as the `context` parameter in the request body.
-      (e.g. '{"foo": "bar"}')
+      (e.g. '{"foo": "bar"}').
+
+      The context can also be supplied by providing data in the workspace, either as
+      sym/context.json or as a collection of files in the sym/context folder.
     default: "{}"
   request_slug:
     type: string
@@ -28,6 +31,9 @@ parameters:
     description: The URL to the Sym API.
     default: "https://api.symops.com/api/v1"
 steps:
+  - run:
+      name: Collect context
+      command: <<include(scripts/collect_context.py)>>
   - run:
       environment:
         FLOW_SRN: <<parameters.flow_srn>>

--- a/src/jobs/deescalate.yml
+++ b/src/jobs/deescalate.yml
@@ -2,7 +2,7 @@ description: >
   De-escalates an existing Sym Run.
 
 docker:
-  - image: bitnami/python:3.10
+  - image: cimg/deploy:2022.07
 
 parameters:
   run_id:

--- a/src/jobs/deescalate.yml
+++ b/src/jobs/deescalate.yml
@@ -2,7 +2,7 @@ description: >
   De-escalates an existing Sym Run.
 
 docker:
-  - image: cimg/aws:2022.06
+  - image: bitnami/python:3.10
 
 parameters:
   run_id:

--- a/src/jobs/request.yml
+++ b/src/jobs/request.yml
@@ -17,7 +17,10 @@ parameters:
     type: string
     description: |
       A valid JSON string containing the object to include as the `context` parameter in the request body.
-      (e.g. '{"foo": "bar"}')
+      (e.g. '{"foo": "bar"}').
+
+      The context can also be supplied by providing data in the workspace, either as
+      sym/context.json or as a collection of files in the sym/context folder.
     default: "{}"
   request_slug:
     type: string

--- a/src/jobs/request.yml
+++ b/src/jobs/request.yml
@@ -33,6 +33,8 @@ parameters:
     description: The URL to the Sym API.
     default: "https://api.symops.com/api/v1"
 steps:
+  - attach_workspace:
+      at: /tmp/workspace
   - run:
       name: Create sym directory
       command: mkdir -p sym

--- a/src/jobs/request.yml
+++ b/src/jobs/request.yml
@@ -2,7 +2,7 @@ description: >
   Makes a Sym Request.
 
 docker:
-  - image: cimg/aws:2022.06
+  - image: bitnami/python:3.10
 
 parameters:
   flow_srn:

--- a/src/jobs/request.yml
+++ b/src/jobs/request.yml
@@ -2,7 +2,7 @@ description: >
   Makes a Sym Request.
 
 docker:
-  - image: bitnami/python:3.10
+  - image: cimg/deploy:2022.07
 
 parameters:
   flow_srn:

--- a/src/jobs/request.yml
+++ b/src/jobs/request.yml
@@ -21,6 +21,8 @@ parameters:
 
       The context can also be supplied by providing data in the workspace, either as
       sym/context.json or as a collection of files in the sym/context folder.
+
+      Binary files in the sym/context folder are not supported. JSON files will be encoded as strings.
     default: "{}"
   request_slug:
     type: string

--- a/src/jobs/validate.yml
+++ b/src/jobs/validate.yml
@@ -2,7 +2,7 @@ description: >
   Validate that a Sym Run is approved.
 
 docker:
-  - image: bitnami/python:3.10
+  - image: cimg/deploy:2022.07
 
 parameters:
   run_id:

--- a/src/jobs/validate.yml
+++ b/src/jobs/validate.yml
@@ -2,7 +2,7 @@ description: >
   Validate that a Sym Run is approved.
 
 docker:
-  - image: cimg/aws:2022.06
+  - image: bitnami/python:3.10
 
 parameters:
   run_id:

--- a/src/scripts/collect_context.py
+++ b/src/scripts/collect_context.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import json
+import os
+import sys
+
+target_dir = os.path.join("sym", "context")
+if not os.path.exists(target_dir):
+    sys.exit(0)
+
+data = {}
+for path in os.listdir(target_dir):
+    full_path = os.path.join(target_dir, path)
+    if os.path.isfile(full_path):
+        with open(full_path, "r") as f:
+            data[path] = f.read().rstrip()
+
+target_path = os.path.join("sym", "context.json")
+with open(target_path, "w") as target:
+    json.dump(data, target)
+print(f"Added context to {target_path}")

--- a/src/scripts/collect_context.sh
+++ b/src/scripts/collect_context.sh
@@ -2,7 +2,11 @@
 set -o pipefail
 set -e
 
-python - <<SCRIPT
+if command -v python >/dev/null 2>&1; then export PYTHON="python"; else
+  export PYTHON="python3";
+fi
+
+$PYTHON - <<SCRIPT
 import json
 import os
 import sys

--- a/src/scripts/collect_context.sh
+++ b/src/scripts/collect_context.sh
@@ -1,5 +1,8 @@
-#!/usr/bin/env python
+#!/bin/bash
+set -o pipefail
+set -e
 
+python - <<SCRIPT
 import json
 import os
 import sys
@@ -19,3 +22,4 @@ target_path = os.path.join("sym", "context.json")
 with open(target_path, "w") as target:
     json.dump(data, target)
 print(f"Added context to {target_path}")
+SCRIPT

--- a/src/scripts/request.sh
+++ b/src/scripts/request.sh
@@ -16,7 +16,7 @@ FLOW_SRN=$(echo $FLOW_SRN | envsubst)
 FLOW_INPUTS=$(echo $FLOW_INPUTS | envsubst)
 CONTEXT=$(echo $CONTEXT | envsubst)
 
-if [[ -z $CONTEXT ]]; then
+if [[ -z $CONTEXT ]] || [[ $CONTEXT == "{}" ]]; then
   # Check if there is a context file to load from if no parameter was specified
   if [[ -f /tmp/workspace/sym/context.json ]]; then
     CONTEXT=$(</tmp/workspace/sym/context.json jq -r)

--- a/src/scripts/request.sh
+++ b/src/scripts/request.sh
@@ -16,6 +16,13 @@ FLOW_SRN=$(echo $FLOW_SRN | envsubst)
 FLOW_INPUTS=$(echo $FLOW_INPUTS | envsubst)
 CONTEXT=$(echo $CONTEXT | envsubst)
 
+if [[ -z $CONTEXT ]]; then
+  # Check if there is a context file to load from if no parameter was specified
+  if [[ -f sym/context.json ]]; then
+    CONTEXT=$(<sym/context.json jq -r)
+  fi
+fi
+
 REQUEST_BODY="$(jq --null-input \
   --arg flow_srn "$FLOW_SRN" \
   --argjson flow_inputs "$FLOW_INPUTS" \

--- a/src/scripts/request.sh
+++ b/src/scripts/request.sh
@@ -18,8 +18,8 @@ CONTEXT=$(echo $CONTEXT | envsubst)
 
 if [[ -z $CONTEXT ]]; then
   # Check if there is a context file to load from if no parameter was specified
-  if [[ -f sym/context.json ]]; then
-    CONTEXT=$(<sym/context.json jq -r)
+  if [[ -f /tmp/workspace/sym/context.json ]]; then
+    CONTEXT=$(</tmp/workspace/sym/context.json jq -r)
   fi
 fi
 


### PR DESCRIPTION
I want to provide context based on the output of an earlier job, and I think the best (only?) way to do this is by adding stuff into the workspace and then having our request job pick it up.